### PR TITLE
Fix IMGHDR_TYPE_*

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -15,7 +15,7 @@ typedef struct {
 } MAIN_CSM;
 
 unsigned char *GetScreenBuffer() {
-    size_t size = CalcBitmapSize((short)ScreenW(), (short)ScreenH(), IMGHDR_TYPE_RGB565);
+    size_t size = CalcBitmapSize((short)ScreenW(), (short)ScreenH(), IMGHDR_TYPE_BGR565);
     unsigned char *buffer = malloc(size);
     memcpy(buffer, RamScreenBuffer(), size);
     return buffer;


### PR DESCRIPTION
Поправил название, чтобы не было путаницы. Порядок байт в сименсе [ BB, GG, RR, AA ], поэтому правильное название констант BGR* и BGRA* вместо RGB* и RGBA*

1. Константа появилась недавно, поэтому старые эльфы не затронет.
2. Пересобирать эльфы не нужно.